### PR TITLE
viski (23161): izměniti gramatičny rod

### DIFF
--- a/synsets/02/31/61/viski.xml
+++ b/synsets/02/31/61/viski.xml
@@ -9,7 +9,7 @@
   <synset lang="art-x-interslv">
     <lemma
       steen:id="23161"
-      steen:pos="m.indecl./f.indecl."
+      steen:pos="m.indecl."
       steen:type="1"
       steen:genesis="E"
     >

--- a/synsets/02/31/61/viski.xml
+++ b/synsets/02/31/61/viski.xml
@@ -9,7 +9,7 @@
   <synset lang="art-x-interslv">
     <lemma
       steen:id="23161"
-      steen:pos="m.indecl."
+      steen:pos="n.indecl."
       steen:type="1"
       steen:genesis="E"
     >


### PR DESCRIPTION
Proponuju izměniti rod imennika `viski`.

**Bylo:**

```
m.indecl./f.indecl.
```

**Bude:**

```
n.indecl.
```

**Alternativno rěšenje:**

```
m.indecl.
```

## Motivacija

Podolg glasovanja jezykov, imajemo prědnost srědnjego (nikakogo) roda nad mužskym i ženskym rodom (2.5/2/**3.5**).

Medžuslovjansky slovnik imaje **11** nesklanjajemyh imennikov mužskogo roda, **21** srědnjego, i samo **1** ženskogo (viki).

Hot i je dovod "compatibility", ale _srědnji rod_ bude lěpše držati balans k regularnosti jezyka, i nehaj bude 11/1/22, než 12/1/21 (m/ž/s).

### Masculine

| Lang | Sentence                         | Score |
|------|----------------------------------|-------|
| BE   | Гэта быў дарагі віскі.           | 0.5   |
| BS   | To je bio skupi viski.           | 0.125 |
| CNR  | ??                               | 0.125 |
| HR   | Bio je to skup viski.            | 0.125 |
| SL   | To je bil drag viski.            | 0.5   |
| SR   | То је био скупи виски.           | 0.125 |
| RU   | Это был дорогой виски.           | 1     |
|      | **Total:**                       | 2.5     |

### Neuter

| Lang | Sentence                         | Score |
|------|----------------------------------|-------|
| BG   | Това беше скъпо уиски.           | 0.5  |
| MK   | Тоа беше скапо виски.      | 0.5  |
| RU   | Это было дорогое[^1] виски.      | 1     |
| UK   | Це було дороге віскі.      | 0.5     |
| PL   | To było droge[^2] whisky.            | 1     |
|      | **Total:**                       | 3.5   |

### Feminine

| Lang | Sentence                         | Score |
|------|----------------------------------|-------|
| CS   | Byla to drahá whisky.            | 0.5   |
| SK   | Bola to drahá whisky.            | 0.5   |
| PL   | To była droga whisky.            | 1     |
|      | **Total:**                       | 2     |

[^1]: slovnikova forma (srědnji rod)
[^2]: razgovorny variant