### PR TITLE
padųčnica (20971): dodati sinonim "epilepsija"

### DIFF
--- a/synsets/02/09/71/paducnica.xml
+++ b/synsets/02/09/71/paducnica.xml
@@ -6,6 +6,7 @@
   xmlns:steen="https://interslavic.fun/schemas/steenbergen.xsd"
 >
   <synset lang="art-x-interslv">
+    <lemma steen:id="20971" steen:pos="f." steen:type="1">epilepsija</lemma>
     <lemma steen:id="20971" steen:pos="f." steen:type="1">padųčnica</lemma>
   </synset>
   <synset lang="en">


### PR DESCRIPTION
Rezultaty iz Wikipedije:

* `en`: Epilepsy 
* `ru`: Эпилепсия
* `be`: Эпілепсія
* `be-x-old`: Эпілепсія
* `uk`: Епілепсія
* `pl`: Padaczka
* `cs`: Epilepsie
* `sk`: Epilepsia
* `bg`: Епилепсия
* `mk`: Епилепсија
* `sr`: Епилепсија
* `hr`: Epilepsija
* `sh`: Epilepsija
* `sl`: Epilepsija