### PR TITLE
Update za.xml

### DIFF
--- a/synsets/03/49/89/za.xml
+++ b/synsets/03/49/89/za.xml
@@ -8,7 +8,7 @@
   <synset lang="art-x-interslv">
     <lemma
       steen:id="34989"
-      steen:addition="(+2)"
+      steen:addition="(+4)"
       steen:pos="prep."
       steen:type="1"
     >


### PR DESCRIPTION
Izpravjenje rekomendujemogo padeža na akuzativ (za jedin časa/dnja/stolětja -> za jedin čas/denj/stolětje)

Iz priměrov vidimo že akuzativ dominuje:

Russian | за месяц
Belarusian | за месяц
Ukrainian | за місяць
Polish | w miesiąc / za miesiąc
Czech | za měsíc
Slovak | Za mesiac
Slovene | za mesec / v mesecu / na mesec
Croatian | za mesec dana
Serbian | za mesec dana
Macedonian |  за месец
Bulgarian | за месец

Jediny znajemy priměr uživanja genitiva jest ukrajinsky (gleděti obrazok):
![photo1694354010](https://github.com/medzuslovjansky/database/assets/48055313/afe6ea79-2174-4973-ab56-d69141b5af1b)
