### PR TITLE
Popraviti korenj "plěn" v slovah "plen" i "pleniti"

### DIFF
--- a/synsets/02/34/03/plen.xml
+++ b/synsets/02/34/03/plen.xml
@@ -12,7 +12,7 @@
       steen:type="2"
       steen:same="cs yu mk (pl)"
     >
-      plen
+      plěn
     </lemma>
   </synset>
   <synset lang="en">

--- a/synsets/02/34/05/pleniti.xml
+++ b/synsets/02/34/05/pleniti.xml
@@ -12,7 +12,7 @@
       steen:type="2"
       steen:same="cs yu mk"
     >
-      pleniti
+      plěniti
     </lemma>
   </synset>
   <synset lang="en">


### PR DESCRIPTION
Slovnik ima slovesa "pl**e**n, pl**e**niti, zapl**ě**niti, zapl**ě**njati". One izgledajut, ako imajut jedno korenje, ale polovina imaje "ě", a druga polovina ima "e". V starom crkovnoslovjanskom to slovo se pisalo kako "плѣнъ".

Словник има словеса "plen, pleniti, zaplěniti, zaplěnjati". Оне изгледают, ако имают jедно коренjе, але половина имаје "ě", а друга половина има "e". В старом црковнословjанском то слово се писало како "плѣнъ".