### PR TITLE
Dodati "entropija" (f.)

### DIFF
--- a/synsets/03/70/64/entropija.xml
+++ b/synsets/03/70/64/entropija.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<multilingual-synset
+  id="37064"
+  xmlns="https://interslavic.fun/schemas/zonal-wordnet.xsd"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:steen="https://interslavic.fun/schemas/steenbergen.xsd"
+>
+  <synset lang="art-x-interslv">
+    <lemma steen:id="37064" steen:pos="f.">entropija</lemma>
+  </synset>
+  <synset lang="en">
+    <lemma annotation="physics">entropy</lemma>
+  </synset>
+  <synset lang="be">
+    <lemma>энтрапія</lemma>
+  </synset>
+  <synset lang="bg">
+    <lemma>ентропия</lemma>
+  </synset>
+  <synset lang="cs">
+    <lemma>entropie</lemma>
+  </synset>
+  <synset lang="hr">
+    <lemma>entropija</lemma>
+  </synset>
+  <synset lang="mk">
+    <lemma>ентропија</lemma>
+  </synset>
+  <synset lang="pl">
+    <lemma>entropia</lemma>
+  </synset>
+  <synset lang="ru">
+    <lemma>энтропия</lemma>
+  </synset>
+  <synset lang="sk">
+    <lemma>entropia</lemma>
+  </synset>
+  <synset lang="sl">
+    <lemma>entropíja</lemma>
+  </synset>
+  <synset lang="sr">
+    <lemma>ентропија</lemma>
+  </synset>
+  <synset lang="uk">
+    <lemma>ентропія</lemma>
+  </synset>
+</multilingual-synset>


### PR DESCRIPTION
## Summary of Changes

### `entropija` (37064) 🆕

- **Part of Speech:** _noun, feminine_

- **Etymology:** _Greek_ - ἐντροπία (entropía), meaning "a turning toward", in the context of physics.

- **Translations:**

| Language | Translation |
|----------|-------------|
| :uk: English | entropy |
| :belarus: Belarusian | энтрапія |
| :bulgaria: Bulgarian | ентропия |
| :czech_republic: Czech | entropie |
| :croatia: Croatian | entropija |
| :macedonia: Macedonian | ентропија |
| :poland: Polish | entropia |
| :ru: Russian | энтропия |
| :slovakia: Slovak | entropia |
| :slovenia: Slovene | entropíja |
| :serbia: Serbian | ентропија |
| :ukraine: Ukrainian | ентропія |

  
- **Declension Table:**

  <details>
  <summary>Click to expand</summary>
  
  | Case | Singular | Plural |
  |------|----------|--------|
  | Nominative | ... | ... |
  | Genitive | ... | ... |
  [Continue with other cases]

  </details>