### PR TITLE
Update stvar.xml

### DIFF
--- a/synsets/01/26/88/stvar.xml
+++ b/synsets/01/26/88/stvar.xml
@@ -6,7 +6,7 @@
   xmlns:steen="https://interslavic.fun/schemas/steenbergen.xsd"
 >
   <synset lang="art-x-interslv">
-    <lemma steen:id="12688" steen:pos="m." steen:type="2" steen:same="j">
+    <lemma steen:id="12688" steen:pos="f." steen:type="2" steen:same="j">
       stvaŕ
     </lemma>
   </synset>

--- a/synsets/01/26/88/stvar.xml
+++ b/synsets/01/26/88/stvar.xml
@@ -7,7 +7,7 @@
 >
   <synset lang="art-x-interslv">
     <lemma steen:id="12688" steen:pos="m." steen:type="2" steen:same="j">
-      stvår
+      stvaŕ
     </lemma>
   </synset>
   <synset lang="en">


### PR DESCRIPTION
Citata od Konstantina: 

"Uže jesmo pisali o tom několiko razy. Myslim, da to je sdělano radi analogije sȯ vsimi drugymi slovami končęćimi sę na -ar. Imenno, vse take slova v MS sųt izključiteljno mųžskogo roda. Jednakže, to ne měnjaje fakt, že slovo stvar v mųžskom rodu:
1. izględa čudno (osoblivo v sklonjeńjah);
2. zvųči neprirodno govoriteljam prirodnyh językov imajųćih go (SL, SH, MK); i takože
3. može dovesti do zaměšańja sȯ shodnym (no ne srodnym) slovom stvor. V koncu, ješče jedna stvaŕ (stuck_out_tongue) jest pogrěšna s tutčasnym slovom stvår v MS slovniku: jego etimologično napisańje. Imenno, samoglåska å v njem ne jest adekvatna, jerbo stvaŕ ima izključiteljno glåskų a vȯ vsih prirodnyh językah imajųćih to slovo. Råzlog jest etimologičny: izhodno praslovjansko slovo jest *sъtvarь, ne **sъtvorь. Iz togože råzloga i poslědnje r dȯlžno byti palatalizovano: ŕ, jerbo proizhodi od prasl. *-rь."