### PR TITLE
synsets(498): kųdeŕ (m. → m./f.)

### DIFF
--- a/synsets/00/04/98/kuder.xml
+++ b/synsets/00/04/98/kuder.xml
@@ -6,7 +6,7 @@
   xmlns:steen="https://interslavic.fun/schemas/steenbergen.xsd"
 >
   <synset lang="art-x-interslv">
-    <lemma steen:id="498" steen:pos="m." steen:type="1">kųdeŕ</lemma>
+    <lemma steen:id="498" steen:pos="m./f." steen:type="1">kųdeŕ</lemma>
   </synset>
   <synset lang="en">
     <lemma>curl</lemma>


### PR DESCRIPTION
Proponuju izměniti rod imennika `kudeŕ` (*kǫderь)

**Bylo:**

```
m.
```

**Bude:**

```
m./f.
```

**Alternativno rěšenje:**

Ne odobrjeno, zatože v russkom jezyku, hot i slovo imaje žensky rod, ale ono praktično ne se koristaje v jednině (singular), i zato glasovanje by bylo někako bliže k 2:2.

```
f.
```

## Motivacija

* Podolg [Maxi-glasovanja jezykov](http://steen.free.fr/interslavic/zalozsenija.html), imajemo prědnost ženskogo roda nad mužskym: 3.5 protiv 2.25.
* Podolg standardnogo glasovanja, takože imajemo prědnost ženskogo roda nad mužskym: 3 protiv 2.

### Mužsky rod

| Jezyk          | Slovo           | Link                                                                                                                  | Baly |
|---------------|----------------|-----------------------------------------------------------------------------------------------------------------------|-------|
| Dolnolužičsky | kuźeŕ  | [Link](https://en.wiktionary.org/wiki/ku%C5%BAe%C5%95#Lower_Sorbian)                                                  | 0.25     |
| Poljsky       | kędzior        | [Link](https://en.wiktionary.org/wiki/k%C4%99dzior)                                                                   | 1     |
| Slovensky     | kóder          | [Link](https://fran.si/201/esskj-slovar-slovenskega-knjiznega-jezika/4572028/koder?View=1&Query=koder&hs=1)           | 0.5     |
| Bělorussky    | ку́дзер        | [Link](https://belarusian_russian.academic.ru/22718/%D0%BA%D1%83%D0%B4%D0%B7%D0%B5%D1%80)                             | 0.5     |
| **Total:**    |                |                                                                                                                       | **2.25** |

### Žensky rod

| Lang          | Word            | Link                                                                                                            | Score |
|---------------|-----------------|-----------------------------------------------------------------------------------------------------------------|-------|
| Dolnolužičsky | kuźera   | [Link](https://en.wiktionary.org/wiki/ku%C5%BAe%C5%95#Lower_Sorbian)                                            | 0.25     |
| Gornolužičsky | kudźer          | [Link](https://en.wiktionary.org/wiki/kud%C5%BAer#Upper_Sorbian)                                                | 0.25     |
| Češsky        | kudrna          | [Link](https://en.wiktionary.org/wiki/kudrna)                                                                   | 0.5     |
| Slovačsky     | kudrlina        |                                                                                                                 | 0.5     |
| Makedonsky    | кадра           | [Link](http://drmj.eu/search/%D0%BA%D0%B0%D0%B4%D1%80%D0%B0#%D0%BA%D0%B0%D0%B4%D1%80%D0%B0/%D0%B6)              | 0.5    |
| Bulgarsky     | къ́дра          | [Link](https://rechnik.chitanka.info/w/%D0%BA%D1%8A%D0%B4%D1%80%D0%B0)                                          | 0.5     |
| Russky        | ку́дри (кудерь) | [Link](https://ru.wiktionary.org/wiki/%D0%BA%D1%83%D0%B4%D1%80%D0%B8)                                           | 1     |
| **Total:**    |                 |                                                                                                                 | **4** |