### PR TITLE
spelling: month names ending with -enj

### DIFF
--- a/synsets/00/66/97/brezenj.xml
+++ b/synsets/00/66/97/brezenj.xml
@@ -7,7 +7,7 @@
 >
   <synset lang="art-x-interslv">
     <lemma steen:id="6697" steen:pos="m.sg." steen:type="2" steen:genesis="S">
-      brězenj
+      brězėnj
     </lemma>
   </synset>
   <synset lang="en">

--- a/synsets/00/68/30/crvenj.xml
+++ b/synsets/00/68/30/crvenj.xml
@@ -7,7 +7,7 @@
 >
   <synset lang="art-x-interslv">
     <lemma steen:id="6830" steen:pos="m.sg." steen:type="2" steen:genesis="S">
-      črvenj
+      črvėnj
     </lemma>
   </synset>
   <synset lang="en">

--- a/synsets/00/87/91/cvetenj.xml
+++ b/synsets/00/87/91/cvetenj.xml
@@ -7,7 +7,7 @@
 >
   <synset lang="art-x-interslv">
     <lemma steen:id="8791" steen:pos="m.sg." steen:type="2" steen:genesis="S">
-      cvětenj
+      cvětėnj
     </lemma>
   </synset>
   <synset lang="en">

--- a/synsets/00/88/90/lipenj.xml
+++ b/synsets/00/88/90/lipenj.xml
@@ -7,7 +7,7 @@
 >
   <synset lang="art-x-interslv">
     <lemma steen:id="8890" steen:pos="m.sg." steen:type="2" steen:genesis="S">
-      lipenj
+      lipėnj
     </lemma>
   </synset>
   <synset lang="en">

--- a/synsets/01/20/39/rujenj.xml
+++ b/synsets/01/20/39/rujenj.xml
@@ -7,7 +7,7 @@
 >
   <synset lang="art-x-interslv">
     <lemma steen:id="12039" steen:pos="m.sg." steen:type="2" steen:genesis="S">
-      rujenj
+      rujėnj
     </lemma>
   </synset>
   <synset lang="en">

--- a/synsets/01/21/65/srpenj.xml
+++ b/synsets/01/21/65/srpenj.xml
@@ -7,7 +7,7 @@
 >
   <synset lang="art-x-interslv">
     <lemma steen:id="12165" steen:pos="m.sg." steen:type="2" steen:genesis="S">
-      sŕpenj
+      sŕpėnj
     </lemma>
   </synset>
   <synset lang="en">

--- a/synsets/01/23/95/snezenj.xml
+++ b/synsets/01/23/95/snezenj.xml
@@ -7,7 +7,7 @@
 >
   <synset lang="art-x-interslv">
     <lemma steen:id="12395" steen:pos="m.sg." steen:type="2" steen:genesis="S">
-      sněženj
+      sněžėnj
     </lemma>
   </synset>
   <synset lang="en">

--- a/synsets/01/26/12/stycenj.xml
+++ b/synsets/01/26/12/stycenj.xml
@@ -13,7 +13,7 @@
       steen:same="pl"
       steen:genesis="S"
     >
-      styčenj
+      styčėnj
     </lemma>
   </synset>
   <synset lang="en">

--- a/synsets/01/30/39/travenj.xml
+++ b/synsets/01/30/39/travenj.xml
@@ -7,7 +7,7 @@
 >
   <synset lang="art-x-interslv">
     <lemma steen:id="13039" steen:pos="m.sg." steen:type="2" steen:genesis="S">
-      travenj
+      travėnj
     </lemma>
   </synset>
   <synset lang="en">

--- a/synsets/01/38/32/vresenj.xml
+++ b/synsets/01/38/32/vresenj.xml
@@ -7,7 +7,7 @@
 >
   <synset lang="art-x-interslv">
     <lemma steen:id="13832" steen:pos="m.sg." steen:type="2" steen:genesis="S">
-      vresenj
+      vresėnj
     </lemma>
   </synset>
   <synset lang="en">

--- a/synsets/02/28/11/secenj.xml
+++ b/synsets/02/28/11/secenj.xml
@@ -7,7 +7,7 @@
 >
   <synset lang="art-x-interslv">
     <lemma steen:id="22811" steen:pos="m.sg." steen:type="2" steen:genesis="S">
-      sěčenj
+      sěčėnj
     </lemma>
   </synset>
   <synset lang="en">


### PR DESCRIPTION
Slovnik imaje nenaturalnost vo vsih měsecah, kako:

| Padež | Forma |
| --- | --- |
| Imen. | styčenj |
| Vin. | styčenj | 
| Rod. | styčenja |
| Měst. | styčenju |
| Dat. | styčenju |
| Tvor. | styčenjem |
| Zvat. | styčenju

Tutoj PR popravjaje logiku sklanjanja:

sěčenj → sěčėnj (sěčnja)
styčenj → styčėnj (styčnja)
brězenj → brězėnj (brěznja)
cvětenj → cvětėnj (cvětnja)
travenj → travėnj (travnja)
črvenj → črvėnj (črvnja)
lipenj → lipėnj (lipnja)
sŕpenj → sŕpėnj (sŕpnja)
vresenj → vrěsėnj (vrěsnja)
rujenj → rujėnj (rujnja)
sněženj → sněžėnj (sněžnja)