### PR TITLE
synsets(13832): vresėnj → vrěsėnj

### DIFF
--- a/synsets/01/38/32/vresenj.xml
+++ b/synsets/01/38/32/vresenj.xml
@@ -8,7 +8,7 @@
 >
   <synset lang="art-x-interslv">
     <lemma steen:id="13832" steen:pos="m.sg." steen:type="2" steen:genesis="S">
-      vresėnj
+      vrěsėnj
     </lemma>
   </synset>
   <synset lang="en">


### PR DESCRIPTION
Slovjańska nazva devętogo měsęca, vrěsėnj, proizhodi od slova vrěs. Tuto slovo už jest v slovniku s jat́jų, tak trěba by bylo izměniti tȯž vresenj daby sȯdŕžal jat́.

Kognaty v prirodnyh językah: PS versьnь/versъ, CU врѣсьнь/врѣсъ, PL wrzesień/wrzos, SH vr(ij)es...