### PR TITLE
Izměnjenje roda slova "peć" na žensky.xml

### DIFF
--- a/synsets/02/09/83/pec.xml
+++ b/synsets/02/09/83/pec.xml
@@ -6,7 +6,7 @@
   xmlns:steen="https://interslavic.fun/schemas/steenbergen.xsd"
 >
   <synset lang="art-x-interslv">
-    <lemma steen:id="20983" steen:pos="m." steen:type="1">peć</lemma>
+    <lemma steen:id="20983" steen:pos="ž." steen:type="1">peć</lemma>
   </synset>
   <synset lang="en">
     <lemma>stove</lemma>

--- a/synsets/02/09/83/pec.xml
+++ b/synsets/02/09/83/pec.xml
@@ -6,7 +6,7 @@
   xmlns:steen="https://interslavic.fun/schemas/steenbergen.xsd"
 >
   <synset lang="art-x-interslv">
-    <lemma steen:id="20983" steen:pos="ž." steen:type="1">peć</lemma>
+    <lemma steen:id="20983" steen:pos="f." steen:type="1">peć</lemma>
   </synset>
   <synset lang="en">
     <lemma>stove</lemma>


### PR DESCRIPTION
ru žensky rod [Эта печка почти остыла.]
be žensky rod [Там печ была, і печка, і стол стаяў.] 
uk žensky rod [Коли вийшла з літака, то здалося, що потрапила у вогняну піч.] 
pl mužsky rod [Tomowi wciąż było zimno, choć stał bezpośrednio przed piecem.] 
cs žensky rod [Pec je rezavá, ale žádné otvory s plynem]  
sk žensky rod [Pec je skoro studená.]
bg žensky rod [Главата му не е над печката по цял ден.] 
mk žensky rod. [Тројца мажи осудени на смрт во огнена печка се спасени од челуста на смртта.] 
sr žensky rod [Hoćeš da se zagreješ na zidanoj peći?] 
hr žensky rod [kovačka peć; metalurška peć]
sl žensky rod [Zelo preprosto: to je podzemna pečica.]

žrla v slovnikah:
češsky: https://bara.ujc.cas.cz/psjc/search.php?hledej=Hledej&heslo=pec&where=hesla&zobraz_ps=ps&zobraz_cards=cards&pocet_karet=3&numcchange=no&not_initial=1 russky: https://ushakovdictionary.ru/word.php?wordid=48354 
bělorussky: https://www.skarnik.by/rusbel/62091
srbsky: https://archive.org/details/Ruskivelikirenik/page/n549/mode/2up 
bulgarsky: https://djvu.online/file/lOsWRX1eL4DcH