### PR TITLE
Allow plural forms of months

### DIFF
--- a/synsets/00/66/97/brezenj.xml
+++ b/synsets/00/66/97/brezenj.xml
@@ -7,7 +7,7 @@
   xmlns:steen="https://interslavic.fun/schemas/steenbergen.xsd"
 >
   <synset lang="art-x-interslv">
-    <lemma steen:id="6697" steen:pos="m.sg." steen:type="2" steen:genesis="S">
+    <lemma steen:id="6697" steen:pos="m." steen:type="2" steen:genesis="S">
       brězėnj
     </lemma>
   </synset>

--- a/synsets/00/68/30/crvenj.xml
+++ b/synsets/00/68/30/crvenj.xml
@@ -7,7 +7,7 @@
   xmlns:steen="https://interslavic.fun/schemas/steenbergen.xsd"
 >
   <synset lang="art-x-interslv">
-    <lemma steen:id="6830" steen:pos="m.sg." steen:type="2" steen:genesis="S">
+    <lemma steen:id="6830" steen:pos="m." steen:type="2" steen:genesis="S">
       črvėnj
     </lemma>
   </synset>

--- a/synsets/00/87/91/cvetenj.xml
+++ b/synsets/00/87/91/cvetenj.xml
@@ -7,7 +7,7 @@
   xmlns:steen="https://interslavic.fun/schemas/steenbergen.xsd"
 >
   <synset lang="art-x-interslv">
-    <lemma steen:id="8791" steen:pos="m.sg." steen:type="2" steen:genesis="S">
+    <lemma steen:id="8791" steen:pos="m." steen:type="2" steen:genesis="S">
       cvětėnj
     </lemma>
   </synset>

--- a/synsets/00/88/90/lipenj.xml
+++ b/synsets/00/88/90/lipenj.xml
@@ -7,7 +7,7 @@
   xmlns:steen="https://interslavic.fun/schemas/steenbergen.xsd"
 >
   <synset lang="art-x-interslv">
-    <lemma steen:id="8890" steen:pos="m.sg." steen:type="2" steen:genesis="S">
+    <lemma steen:id="8890" steen:pos="m." steen:type="2" steen:genesis="S">
       lipėnj
     </lemma>
   </synset>

--- a/synsets/01/20/39/rujenj.xml
+++ b/synsets/01/20/39/rujenj.xml
@@ -7,7 +7,7 @@
   xmlns:steen="https://interslavic.fun/schemas/steenbergen.xsd"
 >
   <synset lang="art-x-interslv">
-    <lemma steen:id="12039" steen:pos="m.sg." steen:type="2" steen:genesis="S">
+    <lemma steen:id="12039" steen:pos="m." steen:type="2" steen:genesis="S">
       rujėnj
     </lemma>
   </synset>

--- a/synsets/01/21/65/srpenj.xml
+++ b/synsets/01/21/65/srpenj.xml
@@ -7,7 +7,7 @@
   xmlns:steen="https://interslavic.fun/schemas/steenbergen.xsd"
 >
   <synset lang="art-x-interslv">
-    <lemma steen:id="12165" steen:pos="m.sg." steen:type="2" steen:genesis="S">
+    <lemma steen:id="12165" steen:pos="m." steen:type="2" steen:genesis="S">
       sŕpėnj
     </lemma>
   </synset>

--- a/synsets/01/23/95/snezenj.xml
+++ b/synsets/01/23/95/snezenj.xml
@@ -7,7 +7,7 @@
   xmlns:steen="https://interslavic.fun/schemas/steenbergen.xsd"
 >
   <synset lang="art-x-interslv">
-    <lemma steen:id="12395" steen:pos="m.sg." steen:type="2" steen:genesis="S">
+    <lemma steen:id="12395" steen:pos="m." steen:type="2" steen:genesis="S">
       sněžėnj
     </lemma>
   </synset>

--- a/synsets/01/26/12/stycenj.xml
+++ b/synsets/01/26/12/stycenj.xml
@@ -9,7 +9,7 @@
   <synset lang="art-x-interslv">
     <lemma
       steen:id="12612"
-      steen:pos="m.sg."
+      steen:pos="m."
       steen:type="3"
       steen:same="pl"
       steen:genesis="S"

--- a/synsets/01/30/39/travenj.xml
+++ b/synsets/01/30/39/travenj.xml
@@ -7,7 +7,7 @@
   xmlns:steen="https://interslavic.fun/schemas/steenbergen.xsd"
 >
   <synset lang="art-x-interslv">
-    <lemma steen:id="13039" steen:pos="m.sg." steen:type="2" steen:genesis="S">
+    <lemma steen:id="13039" steen:pos="m." steen:type="2" steen:genesis="S">
       travėnj
     </lemma>
   </synset>

--- a/synsets/01/38/32/vresenj.xml
+++ b/synsets/01/38/32/vresenj.xml
@@ -7,7 +7,7 @@
   xmlns:steen="https://interslavic.fun/schemas/steenbergen.xsd"
 >
   <synset lang="art-x-interslv">
-    <lemma steen:id="13832" steen:pos="m.sg." steen:type="2" steen:genesis="S">
+    <lemma steen:id="13832" steen:pos="m." steen:type="2" steen:genesis="S">
       vresėnj
     </lemma>
   </synset>

--- a/synsets/02/28/11/secenj.xml
+++ b/synsets/02/28/11/secenj.xml
@@ -7,7 +7,7 @@
   xmlns:steen="https://interslavic.fun/schemas/steenbergen.xsd"
 >
   <synset lang="art-x-interslv">
-    <lemma steen:id="22811" steen:pos="m.sg." steen:type="2" steen:genesis="S">
+    <lemma steen:id="22811" steen:pos="m." steen:type="2" steen:genesis="S">
       sěčėnj
     </lemma>
   </synset>


### PR DESCRIPTION
Removes `sg.` limitation on the part of speech for these words:

* brězėnj
* črvėnj
* cvětėnj
* lipėnj
* rujėnj
* sŕpėnj
* sněžėnj
* travėnj
* vresėnj
* sěčėnj
