### PR TITLE
lemmas: -mreti → -mrěti

### DIFF
--- a/synsets/00/09/77/umreti.xml
+++ b/synsets/00/09/77/umreti.xml
@@ -12,7 +12,7 @@
       steen:pos="v.intr. pf."
       steen:type="1"
     >
-      umreti
+      umrěti
     </lemma>
   </synset>
   <synset lang="en">

--- a/synsets/00/57/69/izumreti.xml
+++ b/synsets/00/57/69/izumreti.xml
@@ -12,7 +12,7 @@
       steen:pos="v.intr. pf."
       steen:type="1"
     >
-      izumreti
+      izumrěti
     </lemma>
   </synset>
   <synset lang="en">

--- a/synsets/03/15/27/zamreti.xml
+++ b/synsets/03/15/27/zamreti.xml
@@ -13,7 +13,7 @@
       steen:type="1"
       steen:same="v pl sl bg"
     >
-      zamreti
+      zamrěti
     </lemma>
   </synset>
   <synset lang="en">


### PR DESCRIPTION
V slovniku **uže** je:
* izmrěti → izmrěti (izmre) 

Tutoj PR koriguje nastupne slova:

* izumreti (izumre) → izumrěti (izumre)
* umreti (umre) → umrěti (umre)
* zamreti (zamre) → zamrěti (zamre)

### Motivacija

https://en.wiktionary.org/wiki/Reconstruction:Proto-Slavic/merti

Praslovjansko `*-merti` v medžuslovjanskom bude `-mrěti` po [Janovym pravilam derivacije (C‍er‍C)](
https://interslavic.fun/learn/vocabulary/derivation/#proto-slavic).

![image](https://github.com/medzuslovjansky/database/assets/1962469/a5fad9f7-c535-4076-a1dc-09c3025c7b6e)

