### PR TITLE
synsets(17335): doživeti → doživati

### DIFF
--- a/synsets/01/73/35/doziveti.xml
+++ b/synsets/01/73/35/doziveti.xml
@@ -12,7 +12,7 @@
       steen:type="1"
       steen:same="v z"
     >
-      doživeti
+      doživati
     </lemma>
   </synset>
   <synset lang="en">


### PR DESCRIPTION
V medžuslovjanskom slovosboru je samo jedin imperfektny glagol s `-živeti`, i vyše 10 s `-živati`.

Podolg Roberto Lombino, tuto izgledaje kako pogrěška (zabezpamečeno slovo iz staryh časov).
Tutoj PR popravjaje staru grěšku.