### PR TITLE
fix: -reti -> -rěti verbs

### DIFF
--- a/synsets/00/15/29/dreti.xml
+++ b/synsets/00/15/29/dreti.xml
@@ -12,7 +12,7 @@
       steen:pos="v.tr. ipf."
       steen:type="1"
     >
-      dreti
+      drěti
     </lemma>
   </synset>
   <synset lang="en">

--- a/synsets/00/38/26/treti.xml
+++ b/synsets/00/38/26/treti.xml
@@ -12,7 +12,7 @@
       steen:pos="v.tr. ipf."
       steen:type="1"
     >
-      treti
+      trěti
     </lemma>
   </synset>
   <synset lang="en">

--- a/synsets/00/55/45/iztreti.xml
+++ b/synsets/00/55/45/iztreti.xml
@@ -12,7 +12,7 @@
       steen:pos="v.tr. pf."
       steen:type="1"
     >
-      iztreti
+      iztrěti
     </lemma>
   </synset>
   <synset lang="en">

--- a/synsets/02/01/05/razdreti.xml
+++ b/synsets/02/01/05/razdreti.xml
@@ -13,7 +13,7 @@
       steen:type="1"
       steen:same="v z j"
     >
-      råzdreti
+      råzdrěti
     </lemma>
   </synset>
   <synset lang="en">

--- a/synsets/02/14/85/protreti.xml
+++ b/synsets/02/14/85/protreti.xml
@@ -12,7 +12,7 @@
       steen:pos="v.tr. pf."
       steen:type="1"
     >
-      protreti
+      protrěti
     </lemma>
   </synset>
   <synset lang="en">

--- a/synsets/02/82/85/natreti.xml
+++ b/synsets/02/82/85/natreti.xml
@@ -13,7 +13,7 @@
       steen:type="1"
       steen:same="v z sl"
     >
-      natreti
+      natrěti
     </lemma>
   </synset>
   <synset lang="en">

--- a/synsets/02/89/62/obtreti.xml
+++ b/synsets/02/89/62/obtreti.xml
@@ -13,7 +13,7 @@
       steen:type="1"
       steen:same="v z"
     >
-      obtreti
+      obtrěti
     </lemma>
   </synset>
   <synset lang="en">

--- a/synsets/02/90/74/oddreti.xml
+++ b/synsets/02/90/74/oddreti.xml
@@ -7,7 +7,7 @@
 >
   <synset lang="art-x-interslv">
     <lemma steen:id="29074" steen:addition="(oddere)" steen:pos="v.tr. pf.">
-      oddreti
+      oddrěti
     </lemma>
   </synset>
   <synset lang="en">

--- a/synsets/02/92/82/odtreti.xml
+++ b/synsets/02/92/82/odtreti.xml
@@ -7,7 +7,7 @@
 >
   <synset lang="art-x-interslv">
     <lemma steen:id="29282" steen:addition="(odtre)" steen:pos="v.tr. pf.">
-      odtreti
+      odtrěti
     </lemma>
   </synset>
   <synset lang="en">

--- a/synsets/03/05/49/raztreti.xml
+++ b/synsets/03/05/49/raztreti.xml
@@ -12,7 +12,7 @@
       steen:pos="v.tr. pf."
       steen:type="2"
     >
-      råztreti
+      råztrěti
     </lemma>
   </synset>
   <synset lang="en">

--- a/synsets/03/40/29/utreti.xml
+++ b/synsets/03/40/29/utreti.xml
@@ -12,7 +12,7 @@
       steen:pos="v.tr. pf."
       steen:type="1"
     >
-      utreti
+      utrěti
     </lemma>
   </synset>
   <synset lang="en">

--- a/synsets/03/40/86/obdreti.xml
+++ b/synsets/03/40/86/obdreti.xml
@@ -13,7 +13,7 @@
       steen:type="2"
       steen:same="v pl"
     >
-      obdreti
+      obdrěti
     </lemma>
   </synset>
   <synset lang="en">

--- a/synsets/03/41/73/obtreti_se.xml
+++ b/synsets/03/41/73/obtreti_se.xml
@@ -13,7 +13,7 @@
       steen:type="1"
       steen:same="v z"
     >
-      obtreti sę
+      obtrěti sę
     </lemma>
   </synset>
   <synset lang="en">

--- a/synsets/03/43/51/sdreti.xml
+++ b/synsets/03/43/51/sdreti.xml
@@ -7,7 +7,7 @@
 >
   <synset lang="art-x-interslv">
     <lemma steen:id="34351" steen:addition="(sdere)" steen:pos="v.tr. pf.">
-      sdreti
+      sdrěti
     </lemma>
   </synset>
   <synset lang="en">

--- a/synsets/03/60/18/prodreti_se.xml
+++ b/synsets/03/60/18/prodreti_se.xml
@@ -13,7 +13,7 @@
       steen:type="1"
       steen:same="v pl j"
     >
-      prodreti sę
+      prodrěti sę
     </lemma>
   </synset>
   <synset lang="en">


### PR DESCRIPTION
Removes inconsistency between similar roots like: ~~dreti~~/drěti [^1], mrěti [^2], ~~preti~~/prěti [^3], trěti [^4].

All of them have similar Proto-Slavic pattern *CerC, attested Church Slavonic -ѣти forms and expected reflexes in living Slavic languages (e.g. _pl._ drzeć, _sh._ drijeti, _ocs._ прѣти, etc.):

[^1]: https://en.wiktionary.org/wiki/Reconstruction:Proto-Slavic/derti
[^2]: https://en.wiktionary.org/wiki/Reconstruction:Proto-Slavic/merti
[^3]: https://en.wiktionary.org/wiki/Reconstruction:Proto-Slavic/perti
[^4]: https://en.wiktionary.org/wiki/Reconstruction:Proto-Slavic/terti
