### PR TITLE
synsets: add demonstrative pronoun duplicates

### DIFF
--- a/synsets/03/70/64/to.xml
+++ b/synsets/03/70/64/to.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<multilingual-synset
+  id="37064"
+  xmlns="https://interslavic.fun/schemas/zonal-wordnet.xsd"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:steen="https://interslavic.fun/schemas/steenbergen.xsd"
+>
+  <synset lang="art-x-interslv">
+    <lemma steen:id="37064" steen:pos="pron.dem." steen:type="1">to</lemma>
+  </synset>
+  <synset lang="en">
+    <lemma>this</lemma>
+    <lemma>that</lemma>
+  </synset>
+  <synset lang="be" verified="false">
+    <lemma>гэта</lemma>
+    <lemma>то</lemma>
+  </synset>
+  <synset lang="bg" verified="false">
+    <lemma>това</lemma>
+    <lemma>онова</lemma>
+  </synset>
+  <synset lang="cs" verified="false">
+    <lemma>toto</lemma>
+    <lemma>tamto</lemma>
+  </synset>
+  <synset lang="hr" verified="false">
+    <lemma>to</lemma>
+    <lemma>ovo</lemma>
+    <lemma>ono</lemma>
+  </synset>
+  <synset lang="mk" verified="false">
+    <lemma>ова</lemma>
+    <lemma>тоа</lemma>
+  </synset>
+  <synset lang="pl" verified="false">
+    <lemma>to</lemma>
+    <lemma>tamto</lemma>
+  </synset>
+  <synset lang="ru">
+    <lemma>это</lemma>
+    <lemma>то</lemma>
+  </synset>
+  <synset lang="sk" verified="false">
+    <lemma>toto</lemma>
+    <lemma>tamto</lemma>
+  </synset>
+  <synset lang="sl" verified="false">
+    <lemma>to</lemma>
+  </synset>
+  <synset lang="sr" verified="false">
+    <lemma>то</lemma>
+    <lemma>ово</lemma>
+    <lemma>оно</lemma>
+  </synset>
+  <synset lang="uk">
+    <lemma>це</lemma>
+    <lemma>то</lemma>
+  </synset>
+</multilingual-synset>

--- a/synsets/03/70/65/tuto.xml
+++ b/synsets/03/70/65/tuto.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<multilingual-synset
+  id="37065"
+  xmlns="https://interslavic.fun/schemas/zonal-wordnet.xsd"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:steen="https://interslavic.fun/schemas/steenbergen.xsd"
+>
+  <synset lang="art-x-interslv">
+    <lemma steen:id="37065" steen:pos="pron.dem." steen:type="1">tuto</lemma>
+  </synset>
+  <synset lang="en">
+    <lemma>this</lemma>
+  </synset>
+  <synset lang="be" verified="false">
+    <lemma>гэта</lemma>
+  </synset>
+  <synset lang="bg" verified="false">
+    <lemma>това</lemma>
+  </synset>
+  <synset lang="cs" verified="false">
+    <lemma>toto</lemma>
+    <lemma>tohle</lemma>
+  </synset>
+  <synset lang="hr" verified="false">
+    <lemma>to</lemma>
+    <lemma>ovo</lemma>
+  </synset>
+  <synset lang="mk" verified="false">
+    <lemma>ова</lemma>
+  </synset>
+  <synset lang="pl" verified="false">
+    <lemma>to</lemma>
+  </synset>
+  <synset lang="ru">
+    <lemma>это</lemma>
+  </synset>
+  <synset lang="sk" verified="false">
+    <lemma>toto</lemma>
+  </synset>
+  <synset lang="sl" verified="false">
+    <lemma>to</lemma>
+    <lemma>tole</lemma>
+  </synset>
+  <synset lang="sr" verified="false">
+    <lemma>то</lemma>
+    <lemma>ово</lemma>
+  </synset>
+  <synset lang="uk">
+    <lemma>це</lemma>
+  </synset>
+</multilingual-synset>

--- a/synsets/03/70/66/tamto.xml
+++ b/synsets/03/70/66/tamto.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<multilingual-synset
+  id="37066"
+  xmlns="https://interslavic.fun/schemas/zonal-wordnet.xsd"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:steen="https://interslavic.fun/schemas/steenbergen.xsd"
+>
+  <synset lang="art-x-interslv">
+    <lemma steen:id="37066" steen:pos="pron.dem." steen:type="1">tamto</lemma>
+  </synset>
+  <synset lang="en">
+    <lemma>that</lemma>
+  </synset>
+  <synset lang="be" verified="false">
+    <lemma>то</lemma>
+  </synset>
+  <synset lang="bg" verified="false">
+    <lemma>онова</lemma>
+  </synset>
+  <synset lang="cs" verified="false">
+    <lemma>tamto</lemma>
+    <lemma>támhleto</lemma>
+  </synset>
+  <synset lang="hr" verified="false">
+    <lemma>to</lemma>
+    <lemma>ono</lemma>
+  </synset>
+  <synset lang="mk" verified="false">
+    <lemma>тоа</lemma>
+  </synset>
+  <synset lang="pl" verified="false">
+    <lemma>to</lemma>
+    <lemma>tamto</lemma>
+  </synset>
+  <synset lang="ru">
+    <lemma>то</lemma>
+  </synset>
+  <synset lang="sk" verified="false">
+    <lemma>tamto</lemma>
+  </synset>
+  <synset lang="sl" verified="false">
+    <lemma>tisto</lemma>
+  </synset>
+  <synset lang="sr" verified="false">
+    <lemma>то</lemma>
+    <lemma>оно</lemma>
+  </synset>
+  <synset lang="uk">
+    <lemma>то</lemma>
+  </synset>
+</multilingual-synset>


### PR DESCRIPTION
## Summary of Changes

### `to` (37064) 🆕

- **Part of Speech:** _demonstrative pronoun_

- **Translations:**

| Language | Translation |
|----------|-------------|
| 🇬🇧 English | this, that |
| 🇧🇾 Belarusian | гэта, то |
| 🇧🇬 Bulgarian | това, онова |
| 🇨🇿 Czech | toto, tamto |
| 🇭🇷 Croatian | to, ovo, ono |
| 🇲🇰 Macedonian | ова, тоа |
| 🇵🇱 Polish | to, tamto |
| 🇷🇺 Russian | это, то |
| 🇸🇰 Slovak | toto, tamto |
| 🇸🇰 Slovene | to |
| 🇸🇰 Serbian | то, ово, оно |
| 🇺🇦 Ukrainian | це, то |

### `tuto` (37065) 🆕

- **Part of Speech:** _demonstrative pronoun_

- **Translations:**

| Language | Translation |
|----------|-------------|
| 🇬🇧 English | this |
| 🇧🇾 Belarusian | гэта |
| 🇧🇬 Bulgarian | това |
| 🇨🇿 Czech | toto, tohle |
| 🇭🇷 Croatian | to, ovo |
| 🇲🇰 Macedonian | ова |
| 🇵🇱 Polish | to |
| 🇷🇺 Russian | это |
| 🇸🇰 Slovak | toto |
| 🇸🇰 Slovene | to, tole |
| 🇸🇰 Serbian | то, ово |
| 🇺🇦 Ukrainian | це |

### `tamto` (37066) 🆕

- **Part of Speech:** _demonstrative pronoun_

- **Translations:**

| Language | Translation |
|----------|-------------|
| 🇬🇧 English | that |
| 🇧🇾 Belarusian | то |
| 🇧🇬 Bulgarian | онова |
| 🇨🇿 Czech | tamto, támhleto |
| 🇭🇷 Croatian | to, ono |
| 🇲🇰 Macedonian | тоа |
| 🇵🇱 Polish | to, tamto |
| 🇷🇺 Russian | то |
| 🇸🇰 Slovak | tamto |
| 🇸🇰 Slovene | tisto |
| 🇸🇰 Serbian | то, оно |
| 🇺🇦 Ukrainian | то |

