### PR TITLE
lemma: change root crkv → cŕkv

### DIFF
--- a/synsets/00/17/07/crkva.xml
+++ b/synsets/00/17/07/crkva.xml
@@ -6,7 +6,7 @@
   xmlns:steen="https://interslavic.fun/schemas/steenbergen.xsd"
 >
   <synset lang="art-x-interslv">
-    <lemma steen:id="1707" steen:pos="f." steen:type="1">crkva</lemma>
+    <lemma steen:id="1707" steen:pos="f." steen:type="1">cŕkva</lemma>
   </synset>
   <synset lang="en">
     <lemma>church</lemma>

--- a/synsets/00/43/86/crkovnoslovjansky.xml
+++ b/synsets/00/43/86/crkovnoslovjansky.xml
@@ -7,7 +7,7 @@
 >
   <synset lang="art-x-interslv">
     <lemma steen:id="4386" steen:pos="adj." steen:type="1">
-      crkȯvnoslovjansky
+      cŕkȯvnoslovjansky
     </lemma>
   </synset>
   <synset lang="en">

--- a/synsets/01/69/28/crkov.xml
+++ b/synsets/01/69/28/crkov.xml
@@ -6,7 +6,7 @@
   xmlns:steen="https://interslavic.fun/schemas/steenbergen.xsd"
 >
   <synset lang="art-x-interslv">
-    <lemma steen:id="16928" steen:pos="f." steen:type="1">crkȯv</lemma>
+    <lemma steen:id="16928" steen:pos="f." steen:type="1">cŕkȯv</lemma>
   </synset>
   <synset lang="en">
     <lemma>church</lemma>

--- a/synsets/01/70/44/starocrkovnoslovjansky.xml
+++ b/synsets/01/70/44/starocrkovnoslovjansky.xml
@@ -7,7 +7,7 @@
 >
   <synset lang="art-x-interslv">
     <lemma steen:id="17044" steen:pos="adj." steen:type="1">
-      starocrkȯvnoslovjansky
+      starocŕkȯvnoslovjansky
     </lemma>
   </synset>
   <synset lang="en">

--- a/synsets/03/51/68/crkovny.xml
+++ b/synsets/03/51/68/crkovny.xml
@@ -6,7 +6,7 @@
   xmlns:steen="https://interslavic.fun/schemas/steenbergen.xsd"
 >
   <synset lang="art-x-interslv">
-    <lemma steen:id="35168" steen:pos="adj." steen:type="1">crkȯvny</lemma>
+    <lemma steen:id="35168" steen:pos="adj." steen:type="1">cŕkȯvny</lemma>
   </synset>
   <synset lang="en">
     <lemma>ecclesiastical</lemma>


### PR DESCRIPTION
It looks like only thanks to the algorithm, we see `ŕ` in the dictionary.

This pull request replaces syllabic `r` with `ŕ` in the canonical forms of lemmas related to church, as it is intended to be, see [Proto-Slavic *cьrky](https://en.wiktionary.org/wiki/Reconstruction:Proto-Slavic/c%D1%8Crky).

