### PR TITLE
stvarno → stvaŕno; stvarnost́ → stvaŕnost́

### DIFF
--- a/synsets/00/32/93/stvarno.xml
+++ b/synsets/00/32/93/stvarno.xml
@@ -7,7 +7,7 @@
 >
   <synset lang="art-x-interslv">
     <lemma steen:id="3293" steen:pos="adv." steen:type="2" steen:same="yu mk">
-      stvarno
+      stvaŕno
     </lemma>
   </synset>
   <synset lang="en">

--- a/synsets/02/01/91/stvarnost.xml
+++ b/synsets/02/01/91/stvarnost.xml
@@ -7,7 +7,7 @@
 >
   <synset lang="art-x-interslv">
     <lemma steen:id="20191" steen:pos="f." steen:type="2" steen:same="yu mk">
-      stvarnosť
+      stvaŕnosť
     </lemma>
   </synset>
   <synset lang="en">


### PR DESCRIPTION
Slovo proizhodi od *sъtvarь (https://en.wiktionary.org/wiki/Reconstruction:Proto-Slavic/s%D1%8Atvar%D1%8C).