### PR TITLE
råboči → råboći

### DIFF
--- a/synsets/02/01/01/raboci.xml
+++ b/synsets/02/01/01/raboci.xml
@@ -6,7 +6,7 @@
   xmlns:steen="https://interslavic.fun/schemas/steenbergen.xsd"
 >
   <synset lang="art-x-interslv">
-    <lemma steen:id="20101" steen:pos="adj." steen:type="1">råboči</lemma>
+    <lemma steen:id="20101" steen:pos="adj." steen:type="1">råboći</lemma>
   </synset>
   <synset lang="en">
     <lemma>labour</lemma>


### PR DESCRIPTION
Tuto i _izkonavči_ sųt jedine pridavniky končęće sę na _-či_ vměsto _-ći_.

_råboći_ < PS _*orbo**ť**ь_ < _*orbota_ + _*jь_